### PR TITLE
Increase memory for java application to 4G

### DIFF
--- a/deploy/manifest.yml.template
+++ b/deploy/manifest.yml.template
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: <pair-app-name>
-  memory: 512M
+  memory: 4G
   instances: 1
   host: <pair-app-host>
   path: target/ROOT.war


### PR DESCRIPTION
The pairing app fails to start with 512M. I have to admit that I didn't try to find a minimum working value.