### PR TITLE
Improve 7 tests

### DIFF
--- a/src/test/java/pair/distribution/app/helpers/DayPairsHelperTest.java
+++ b/src/test/java/pair/distribution/app/helpers/DayPairsHelperTest.java
@@ -113,7 +113,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subject.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(2));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2"));
 		assertThat(dayPairs.getPairByTrack("track1"),
 				is(not(new Pair(Arrays.asList(new Developer("dev1"), new Developer("dev2"))))));
 		assertThat(dayPairs.getPairByTrack("track2"),
@@ -137,7 +137,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subjectWithEverydayRotation.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(2));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2"));
 		assertThat(dayPairs.getPairByTrack("track1"),
 				is(not(new Pair(Arrays.asList(new Developer("dev1"), new Developer("dev2"))))));
 		assertThat(dayPairs.getPairByTrack("track2"),
@@ -161,7 +161,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subject.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(3));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2", "track3"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2", "track3"));
 		System.out.println(dayPairs.getPairs());
 		assertThat(dayPairs.hasPair(new Pair(Arrays.asList(new Developer("dev1"), new Developer("dev6")))), is(true));
 		assertThat(dayPairs.hasPair(new Pair(Arrays.asList(new Developer("dev3"), new Developer("dev2")))), is(true));
@@ -178,7 +178,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subject.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(2));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2"));
 		assertThat(dayPairs.getPairByTrack("track1"),
 				is((new Pair(Arrays.asList(new Developer("dev1"), new Developer("dev2"))))));
 	}
@@ -209,7 +209,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subject.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(2));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2"));
 		assertThat(dayPairs.hasPair(new Pair(Arrays.asList(new Developer("dev1"), new Developer("dev4")))), is(true));
 		assertThat(dayPairs.hasPair(new Pair(Arrays.asList(new Developer("dev3")))), is(true));
 		boolean trackOneHasContext = dayPairs.getPairByTrack("track1").getFirstDev().hasContext() || dayPairs.getPairByTrack("track1").getSecondDev().hasContext();
@@ -271,7 +271,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subject.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(2));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2"));
 	}
 
 	@Test
@@ -285,7 +285,7 @@ public class DayPairsHelperTest {
 		DayPairs dayPairs = subjectWithEverydayRotation.generateNewDayPairs(tracks, devs, pairs, pairsWeight, getStandardCompanies());
 
 		assertThat(dayPairs.getTracks().size(), is(2));
-		assertThat(dayPairs.getTracks(), contains("track1", "track2"));
+		assertThat(dayPairs.getTracks(), hasItems("track1", "track2"));
 	}
 
 	@Test


### PR DESCRIPTION
## The Issue

These tests calls `contains()` for `assertThat()` calls, which may fall victim to the non-deterministic specification for a method that it calls implicitly.

## Reproduce

The plugin [NonDex](https://github.com/TestingResearchIllinois/NonDex) can be used to help identify code that relies on non-deterministic specifications. For instance, the following steps can be used to examine a particular test:

```
git clone https://github.com/SAP/pair-distribution-app && cd pair-distribution-app
mvn clean install -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=pair.distribution.app.helpers.DayPairsHelperTest#testGenerateNewDayPairs
mvn edu.illinois:nondex-maven-plugin:1.1.2:debug
```

Upon examination, HashMap Iterator was called implicitly during the process. And according to Java specification:

> Hash table based implementation of the Map interface. This implementation provides all of the optional map operations, and permits null values and the null key. (The HashMap class is roughly equivalent to Hashtable, except that it is unsynchronized and permits nulls.) **This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.**

## Solution

`hasItems()` would be a safer call, and combining with assetion on the size of the object udner test, it would still maintain the original intention of the tests.

Please do comment on whether you think this fix is good, and give some advices if it's not, thank you :)